### PR TITLE
Fleet renewal with no new aircraft

### DIFF
--- a/aeromaps/models/air_transport/aircraft_fleet_and_operations/fleet/fleet_model.py
+++ b/aeromaps/models/air_transport/aircraft_fleet_and_operations/fleet/fleet_model.py
@@ -706,15 +706,17 @@ class FleetModel(AeromapsModel):
                 + ":"
                 + "recent_reference:single_aircraft_share"
             ]
-
-            next_aircraft_single_share = self.df[
-                category.name
-                + ":"
-                + category.subcategories[0].name
-                + ":"
-                + subcategory.aircraft[0].name
-                + ":single_aircraft_share"
-            ]
+            if subcategory.aircraft:
+                next_aircraft_single_share = self.df[
+                    category.name
+                    + ":"
+                    + category.subcategories[0].name
+                    + ":"
+                    + subcategory.aircraft[0].name
+                    + ":single_aircraft_share"
+                ]
+            else:
+                next_aircraft_single_share = 0.0
             var_name = (
                 category.name
                 + ":"


### PR DESCRIPTION
This PR resolves #27 by allowing fleet renewal models with no new aircraft and thus technology frozen to prospection start year.