### PR TITLE
Correction for disciplines only dependent of fleet model

### DIFF
--- a/aeromaps/core/process.py
+++ b/aeromaps/core/process.py
@@ -1,7 +1,6 @@
 import os.path as pth
 from json import dump
 from dataclasses import fields
-
 import numpy as np
 import pandas as pd
 
@@ -119,11 +118,17 @@ class AeromapsProcess(object):
         )
 
     def compute(self):
+
         if self.fleet is not None:
             self.fleet_model.compute()
             self.models["passenger_aircraft_efficiency_complex"].fleet_model = self.fleet_model
+            self.models["passenger_aircraft_doc_non_energy_complex"].fleet_model = self.fleet_model
 
         input_data = self._set_inputs()
+
+        if self.fleet is not None:
+            # This is needed since fleet model is particular discipline
+            input_data["dummy_fleet_model_output"] = np.random.rand(1, 1)
 
         self.process.execute(input_data=input_data)
 

--- a/aeromaps/models/air_transport/aircraft_fleet_and_operations/fleet/aircraft_efficiency.py
+++ b/aeromaps/models/air_transport/aircraft_fleet_and_operations/fleet/aircraft_efficiency.py
@@ -260,6 +260,7 @@ class PassengerAircraftEfficiencyComplex(AeromapsModel):
 
     def compute(
         self,
+        dummy_fleet_model_output: np.ndarray,
         energy_consumption_init: pd.Series = pd.Series(dtype="float64"),
         ask: pd.Series = pd.Series(dtype="float64"),
         short_range_energy_share_2019: float = 0.0,

--- a/aeromaps/models/impacts/costs/operations/average_ops_cost.py
+++ b/aeromaps/models/impacts/costs/operations/average_ops_cost.py
@@ -16,6 +16,7 @@ class PassengerAircraftDocNonEnergyComplex(AeromapsModel):
 
     def compute(
         self,
+        dummy_fleet_model_output: np.ndarray,
         ask_long_range_hydrogen_share: pd.Series = pd.Series(dtype="float64"),
         ask_long_range_dropin_fuel_share: pd.Series = pd.Series(dtype="float64"),
         ask_medium_range_hydrogen_share: pd.Series = pd.Series(dtype="float64"),
@@ -118,8 +119,6 @@ class PassengerAircraftDocNonEnergyComplex(AeromapsModel):
         ] = doc_non_energy_per_ask_short_range_mean
 
         self.df.loc[:, "doc_non_energy_per_ask_mean"] = doc_non_energy_per_ask_mean
-
-
 
         return (
             doc_non_energy_per_ask_short_range_dropin_fuel,
@@ -703,6 +702,8 @@ class PassengerAircraftTotalDoc(AeromapsModel):
         self.df.loc[:, "doc_total_per_ask_medium_range_mean"] = doc_total_per_ask_medium_range_mean
         self.df.loc[:, "doc_total_per_ask_long_range_mean"] = doc_total_per_ask_long_range_mean
         self.df.loc[:, "doc_total_per_ask_mean"] = doc_total_per_ask_mean
+
+        print(doc_total_per_ask_mean)
 
         return (
             doc_total_per_ask_short_range_dropin_fuel,


### PR DESCRIPTION
This PR enables to correct a behaviour where disciplines that depend only on the fleet model are not executed.
This is the case of some cost models. For coherence, the logic is also implemented for efficiency models even if they do not only depend on the fleet model.