### PR TITLE
fix(mda): unpin the residual floor, stop column duplication, allow global disciplines in unified_mda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ Changed:
 - Made prospection_start_year flexible. (#146, #149)
 - Refactored markets in AeroMAPS for a fully generic yaml description, with interactions with fleet. (#145)
 - Documentation update. (#154)
+- Added `regionalisation.global_models` and `regionalisation.mda` blocks, allowing non-namespaced disciplines coupled across regions in `unified_mda` mode. (#157)
 
 Fixed:
 - Fixed drop_in_macc_curve plot: updated variable names to match generic energy model naming convention. (#136)
 - Corrected reference outputs of JOAS notebook. (#143)
 - Corrected docs and workflow. (#155)
+- Fixed disciplines mutating their MDA inputs in place, which corrupted GEMSEO's previous-iterate snapshot and pinned the normalised residual above the requested tolerance. (#157)
+- Fixed multi-regional outputs being duplicated on every repeated `compute()`. (#157)
 
 
 ## Version 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changed:
 - Made prospection_start_year flexible. (#146, #149)
 - Refactored markets in AeroMAPS for a fully generic yaml description, with interactions with fleet. (#145)
 - Documentation update. (#154)
-- Added `regionalisation.global_models` and `regionalisation.mda` blocks, allowing non-namespaced disciplines coupled across regions in `unified_mda` mode. (#157)
+- Added a `regionalisation.global_models` block, allowing non-namespaced disciplines coupled across regions in `unified_mda` mode. (#157)
 
 Fixed:
 - Fixed drop_in_macc_curve plot: updated variable names to match generic energy model naming convention. (#136)

--- a/aeromaps/core/multi_regional_process.py
+++ b/aeromaps/core/multi_regional_process.py
@@ -49,6 +49,34 @@ from aeromaps.plots.single_scenario import (
 ExecutionMode = Literal["unified_mda", "separate_processes"]
 
 
+def _concat_series(frame: pd.DataFrame, series: Dict[str, pd.Series]) -> pd.DataFrame:
+    """Add ``series`` as columns of ``frame``, replacing any column of the same name.
+
+    Columns are concatenated in one pass to avoid DataFrame fragmentation. Names
+    already present in ``frame`` are dropped first: ``compute()`` may be called more
+    than once on the same process, and without this the second call appended a second
+    copy of every column instead of refreshing it.
+
+    Parameters
+    ----------
+    frame
+        The existing DataFrame (returned unchanged when ``series`` is empty).
+    series
+        Mapping of column name to Series.
+
+    Returns
+    -------
+    pd.DataFrame
+        The frame with the new columns.
+    """
+    if not series:
+        return frame
+    stale = [col for col in frame.columns if col in series]
+    if stale:
+        frame = frame.drop(columns=stale)
+    return pd.concat([frame] + [pd.DataFrame({k: v}) for k, v in series.items()], axis=1)
+
+
 class _GlobalOutputsView:
     """Single-scenario-process facade over a MultiRegionalProcess' aggregated outputs.
 
@@ -983,18 +1011,8 @@ class MultiRegionalProcess(AeroMAPSProcess):
                 self.data["float_outputs"][key] = float(value)
 
         # Build DataFrames efficiently using concat to avoid fragmentation
-        if vector_series:
-            self.data["vector_outputs"] = pd.concat(
-                [self.data["vector_outputs"]]
-                + [pd.DataFrame({k: v}) for k, v in vector_series.items()],
-                axis=1,
-            )
-        if climate_series:
-            self.data["climate_outputs"] = pd.concat(
-                [self.data["climate_outputs"]]
-                + [pd.DataFrame({k: v}) for k, v in climate_series.items()],
-                axis=1,
-            )
+        self.data["vector_outputs"] = _concat_series(self.data["vector_outputs"], vector_series)
+        self.data["climate_outputs"] = _concat_series(self.data["climate_outputs"], climate_series)
 
     def _update_data_from_unified_mda(self):
         """Update all data structures from unified MDA results.
@@ -1053,18 +1071,8 @@ class MultiRegionalProcess(AeroMAPSProcess):
                     self.data["float_outputs"][key] = float(value)
 
         # Build DataFrames efficiently using concat to avoid fragmentation
-        if vector_series:
-            self.data["vector_outputs"] = pd.concat(
-                [self.data["vector_outputs"]]
-                + [pd.DataFrame({k: v}) for k, v in vector_series.items()],
-                axis=1,
-            )
-        if climate_series:
-            self.data["climate_outputs"] = pd.concat(
-                [self.data["climate_outputs"]]
-                + [pd.DataFrame({k: v}) for k, v in climate_series.items()],
-                axis=1,
-            )
+        self.data["vector_outputs"] = _concat_series(self.data["vector_outputs"], vector_series)
+        self.data["climate_outputs"] = _concat_series(self.data["climate_outputs"], climate_series)
 
     # =========================================================================
     # Data Access Methods

--- a/aeromaps/core/multi_regional_process.py
+++ b/aeromaps/core/multi_regional_process.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional, Literal
 # Third-party imports
 import numpy as np
 import pandas as pd
+from gemseo.algos.sequence_transformer.acceleration import AccelerationMethod
 from gemseo.mda.mda_chain import MDAChain
 from tqdm.auto import tqdm
 
@@ -685,22 +686,37 @@ class MultiRegionalProcess(AeroMAPSProcess):
 
         # Build MDAChain
         # TODO: Make these kwargs available at a higher level (e.g. config file).
-        #
         # Until then they are tuned from the notebook on the GEMSEO objects themselves,
-        # e.g. ``process.mda_chain.settings.tolerance = 1e-10``. One trap is worth
-        # knowing about: ``MDAChain`` forwards to its inner MDAs only the settings that
-        # belong to ``BaseMDASettings`` (``tolerance``, ``max_mda_iter``, ``warm_start``,
-        # ``log_convergence``, ...). ``over_relaxation_factor`` and
-        # ``acceleration_method`` are NOT in that set, so setting them here or on the
-        # chain configures the outer chain only and is silently ignored by the solver
-        # that actually iterates -- they have to be set on ``mda_chain.inner_mdas[i]``
-        # (or passed as ``inner_mda_settings``).
+        # e.g. ``process.mda_chain.settings.tolerance = 1e-10``.
+        #
+        # ``inner_mda_settings`` is listed separately on purpose: it is the only route to
+        # the relaxation/acceleration knobs. ``MDAChain`` forwards to its inner MDAs only
+        # the settings belonging to ``BaseMDASettings`` (``tolerance``, ``max_mda_iter``,
+        # ``warm_start``, ``log_convergence``, ...), and ``over_relaxation_factor`` /
+        # ``acceleration_method`` are NOT in that set, so passing them as ``MDAChain``
+        # kwargs configures the outer chain alone and is silently ignored by the solver
+        # that actually iterates.
+        #
+        # The values below are the MDAGaussSeidel defaults (no damping, no acceleration),
+        # so the chain behaves exactly as before. To change them from a notebook, assign
+        # to the *properties* of the inner solver, not to its settings::
+        #
+        #     process.mda_chain.inner_mdas[0].over_relaxation_factor = 0.7
+        #     process.mda_chain.inner_mdas[0].acceleration_method = "Alternate2Delta"
+        #
+        # ``BaseMDASolver.__init__`` builds its ``RelaxationAcceleration`` from the
+        # settings once and never re-reads them; those two properties write through to it,
+        # whereas assigning to ``inner_mdas[0].settings.*`` afterwards has no effect.
         self.mda_chain = MDAChain(
             disciplines=all_disciplines,
             tolerance=1e-5,
             initialize_defaults=True,
             inner_mda_name="MDAGaussSeidel",
             log_convergence=True,
+            inner_mda_settings={
+                "over_relaxation_factor": 1.0,
+                "acceleration_method": AccelerationMethod.NONE,
+            },
         )
 
         logging.info(f"Unified MDAChain created with {len(all_disciplines)} disciplines")

--- a/aeromaps/core/multi_regional_process.py
+++ b/aeromaps/core/multi_regional_process.py
@@ -683,47 +683,27 @@ class MultiRegionalProcess(AeroMAPSProcess):
 
         self.disciplines = all_disciplines
 
-        self.mda_chain = MDAChain(disciplines=all_disciplines, **self._mda_settings())
+        # Build MDAChain
+        # TODO: Make these kwargs available at a higher level (e.g. config file).
+        #
+        # Until then they are tuned from the notebook on the GEMSEO objects themselves,
+        # e.g. ``process.mda_chain.settings.tolerance = 1e-10``. One trap is worth
+        # knowing about: ``MDAChain`` forwards to its inner MDAs only the settings that
+        # belong to ``BaseMDASettings`` (``tolerance``, ``max_mda_iter``, ``warm_start``,
+        # ``log_convergence``, ...). ``over_relaxation_factor`` and
+        # ``acceleration_method`` are NOT in that set, so setting them here or on the
+        # chain configures the outer chain only and is silently ignored by the solver
+        # that actually iterates -- they have to be set on ``mda_chain.inner_mdas[i]``
+        # (or passed as ``inner_mda_settings``).
+        self.mda_chain = MDAChain(
+            disciplines=all_disciplines,
+            tolerance=1e-5,
+            initialize_defaults=True,
+            inner_mda_name="MDAGaussSeidel",
+            log_convergence=True,
+        )
 
         logging.info(f"Unified MDAChain created with {len(all_disciplines)} disciplines")
-
-    def _mda_settings(self) -> dict:
-        """Resolve the MDAChain settings, overridable from the configuration file.
-
-        Read from an optional ``regionalisation.mda`` block::
-
-            regionalisation:
-              mda:
-                tolerance: 1.0e-10
-                max_mda_iter: 200
-                inner_mda_name: MDAGaussSeidel
-                log_convergence: true
-                inner_mda_settings:
-                  over_relaxation_factor: 0.7
-                  acceleration_method: Alternate2Delta
-
-        ``inner_mda_settings`` is load-bearing and easy to get wrong: ``MDAChain``
-        forwards to its inner MDAs only the settings that belong to
-        ``BaseMDASettings`` (``tolerance``, ``max_mda_iter``, ``warm_start``,
-        ``log_convergence``, ...). ``over_relaxation_factor`` and
-        ``acceleration_method`` are NOT in that set, so passing them as top-level
-        ``MDAChain`` kwargs configures the outer chain only and is silently ignored by
-        the solver that actually iterates. They must go through ``inner_mda_settings``.
-
-        Returns
-        -------
-        dict
-            Keyword arguments for the ``MDAChain`` constructor.
-        """
-        settings = {
-            "tolerance": 1e-5,
-            "initialize_defaults": True,
-            "inner_mda_name": "MDAGaussSeidel",
-            "log_convergence": True,
-        }
-        user_settings = self._regionalisation_config.get("mda", {}) or {}
-        settings.update(user_settings)
-        return settings
 
     def _initialize_data_containers(self):
         """Initialize data containers following AeroMAPSProcess structure.

--- a/aeromaps/core/multi_regional_process.py
+++ b/aeromaps/core/multi_regional_process.py
@@ -191,6 +191,10 @@ class MultiRegionalProcess(AeroMAPSProcess):
         # Load optional top-level models that run on aggregated (global-namespace) data
         self._load_top_level_models()
 
+        # Load optional global models: disciplines that are NOT namespaced and whose
+        # grammar spans several regions at once (see _load_global_models).
+        self._load_global_models()
+
         # Reference parameters (year indexing, etc.) from the first region. Needed
         # before building top-level disciplines so models can initialize their dataframes.
         self.parameters = self._regional_processes[self._region_ids[0]].parameters
@@ -369,17 +373,29 @@ class MultiRegionalProcess(AeroMAPSProcess):
         models
             Dict whose values are either AeroMAPSModel instances or nested dicts of them.
         """
+        self._register_models_into(models, self._top_level_model_names)
+
+    def _register_models_into(self, models, name_list):
+        """Recursively register AeroMAPSModel instances into ``self.models``.
+
+        Parameters
+        ----------
+        models
+            Dict whose values are either AeroMAPSModel instances or nested dicts of them.
+        name_list
+            List that collects the registered model names (mutated in place).
+        """
         from aeromaps.models.base import AeroMAPSModel
 
         for key, value in models.items():
             if isinstance(value, dict):
-                self._register_top_level_models(value)
+                self._register_models_into(value, name_list)
             elif isinstance(value, AeroMAPSModel):
                 self.models[value.name] = value
-                self._top_level_model_names.append(value.name)
+                name_list.append(value.name)
             else:
                 raise TypeError(
-                    f"Top-level model entry '{key}' is not an AeroMAPSModel instance "
+                    f"Model entry '{key}' is not an AeroMAPSModel instance "
                     f"(got {type(value).__name__})."
                 )
 
@@ -455,6 +471,129 @@ class MultiRegionalProcess(AeroMAPSProcess):
             AeroMAPSCustomModelWrapper(model=self.models["aggregator"])
         ] + self._build_namespaced_top_level_disciplines()
 
+    # =========================================================================
+    # Global (non-namespaced) models
+    # =========================================================================
+
+    def _load_global_models(self):
+        """Load optional *global* models: disciplines deliberately kept OUT of namespacing.
+
+        A global model differs from a top-level model on one axis only, but it is a
+        decisive one:
+
+        - a **top-level** model is namespaced to ``self._global_namespace``, so it can
+          only see the aggregated ``{global_namespace}:*`` series. It is a consumer of
+          aggregates, downstream of the aggregator.
+        - a **global** model is *not* namespaced at all. Its grammar is written directly
+          in namespaced terms (``{region}:var``), exactly like ``RegionalAggregator``'s,
+          so it can read one region's variable and write another's. That is what makes
+          it able to close an inter-regional coupling loop — e.g. a fuel market whose
+          clearing price in every region depends on total demand across all regions.
+
+        Declared under ``regionalisation.global_models`` with the same
+        ``standards``/``customs`` structure as a regional ``models`` block::
+
+            regionalisation:
+              execution_mode: unified_mda
+              global_models:
+                customs:
+                  fuel_market: "models/fuel_market.py::FuelMarket"
+
+        Because the region list is not knowable by the model itself, it is injected
+        before ``custom_setup()`` runs (see :meth:`_wrap_global_model`), mirroring how
+        ``AeroMAPSProcess`` injects ``markets`` / ``pathways_manager`` into regional
+        models before calling their ``custom_setup()``.
+
+        Global models only make sense in ``unified_mda`` mode: ``separate_processes``
+        solves each region in isolation and cannot close a loop across regions.
+        """
+        self._global_model_names = []
+
+        global_config = self._regionalisation_config.get("global_models", {})
+        if not global_config:
+            return
+
+        loaded = {}
+        for model_name in global_config.get("standards", []):
+            if hasattr(aeromaps_models, model_name):
+                loaded[model_name] = getattr(aeromaps_models, model_name)
+            else:
+                raise ValueError(
+                    f"Global model '{model_name}' specified in 'regionalisation."
+                    f"global_models.standards' is not found in aeromaps.core.models."
+                )
+
+        customs = global_config.get("customs", None)
+        if customs is not None:
+            loaded.update(self._load_custom_models_from_config(customs))
+
+        self._register_models_into(loaded, self._global_model_names)
+
+        logging.info(
+            f"Loaded {len(self._global_model_names)} global model(s): "
+            f"{self._global_model_names}"
+        )
+
+    def _wrap_global_model(self, model):
+        """Initialize and wrap a single global model as a NON-namespaced discipline.
+
+        Unlike :meth:`_wrap_top_level_model` this method:
+
+        - injects the region list (``model.regions``) and the global namespace
+          (``model.global_namespace``) when the model declares those attributes, and
+        - calls ``custom_setup()`` afterwards, so a model that builds its I/O names
+          dynamically from the region list gets a real grammar instead of the
+          placeholder set in its ``__init__``.
+
+        ``_initialize_df()`` is called twice on purpose: once before ``custom_setup()``
+        so the model has its year index while building its grammar, and once after so
+        that ``_coupling_defaults`` — which typically needs the region list — is rebuilt
+        against the final configuration.
+
+        Parameters
+        ----------
+        model
+            The AeroMAPSModel instance to wrap.
+
+        Returns
+        -------
+        Discipline
+            The wrapped, NOT namespaced, GEMSEO discipline.
+        """
+        model.parameters = self.parameters
+        model._initialize_df()
+
+        if hasattr(model, "climate_historical_data"):
+            raise NotImplementedError(
+                f"Global model '{model.name}' requires climate_historical_data, which is "
+                "not available at the global level."
+            )
+
+        if hasattr(model, "regions"):
+            model.regions = list(self._region_ids)
+        if hasattr(model, "global_namespace"):
+            model.global_namespace = self._global_namespace
+
+        if hasattr(model, "custom_setup"):
+            model.custom_setup()
+
+        # Rebuild the year frames / coupling seeds now that the model is configured.
+        model._initialize_df()
+
+        if getattr(model, "model_type") == "custom":
+            return AeroMAPSCustomModelWrapper(model=model)
+        return AeroMAPSAutoModelWrapper(model=model)
+
+    def _build_global_disciplines(self):
+        """Build the global model disciplines, deliberately WITHOUT namespacing.
+
+        Returns
+        -------
+        list
+            List of GEMSEO disciplines (empty if no global models).
+        """
+        return [self._wrap_global_model(self.models[name]) for name in self._global_model_names]
+
     def _setup_separate_processes(self):
         """Set up separate_processes mode.
 
@@ -464,6 +603,14 @@ class MultiRegionalProcess(AeroMAPSProcess):
         processes, fed with their namespaced outputs. This replaces the previous bespoke
         aggregator call with a normal MDA execution.
         """
+        if self._global_model_names:
+            raise NotImplementedError(
+                f"Global model(s) {self._global_model_names} are declared under "
+                "'regionalisation.global_models', but execution_mode is "
+                "'separate_processes'. A global model exists to close a coupling loop "
+                "across regions, which only 'unified_mda' can solve."
+            )
+
         self.mda_chain = None
         self.disciplines = self._build_top_level_disciplines()
         self._top_level_mda_chain = MDAChain(
@@ -502,19 +649,53 @@ class MultiRegionalProcess(AeroMAPSProcess):
         # couple to the aggregator's outputs within the single MDAChain.
         all_disciplines.extend(self._build_namespaced_top_level_disciplines())
 
+        # Add optional global models. These are NOT namespaced: their grammar already
+        # spans regions, which is what lets them close an inter-regional coupling loop.
+        all_disciplines.extend(self._build_global_disciplines())
+
         self.disciplines = all_disciplines
 
-        # Build MDAChain
-        # TODO: Make these kwargs available at a higher level (e.g. config file).
-        self.mda_chain = MDAChain(
-            disciplines=all_disciplines,
-            tolerance=1e-5,
-            initialize_defaults=True,
-            inner_mda_name="MDAGaussSeidel",
-            log_convergence=True,
-        )
+        self.mda_chain = MDAChain(disciplines=all_disciplines, **self._mda_settings())
 
         logging.info(f"Unified MDAChain created with {len(all_disciplines)} disciplines")
+
+    def _mda_settings(self) -> dict:
+        """Resolve the MDAChain settings, overridable from the configuration file.
+
+        Read from an optional ``regionalisation.mda`` block::
+
+            regionalisation:
+              mda:
+                tolerance: 1.0e-10
+                max_mda_iter: 200
+                inner_mda_name: MDAGaussSeidel
+                log_convergence: true
+                inner_mda_settings:
+                  over_relaxation_factor: 0.7
+                  acceleration_method: Alternate2Delta
+
+        ``inner_mda_settings`` is load-bearing and easy to get wrong: ``MDAChain``
+        forwards to its inner MDAs only the settings that belong to
+        ``BaseMDASettings`` (``tolerance``, ``max_mda_iter``, ``warm_start``,
+        ``log_convergence``, ...). ``over_relaxation_factor`` and
+        ``acceleration_method`` are NOT in that set, so passing them as top-level
+        ``MDAChain`` kwargs configures the outer chain only and is silently ignored by
+        the solver that actually iterates. They must go through ``inner_mda_settings``.
+
+        Returns
+        -------
+        dict
+            Keyword arguments for the ``MDAChain`` constructor.
+        """
+        settings = {
+            "tolerance": 1e-5,
+            "initialize_defaults": True,
+            "inner_mda_name": "MDAGaussSeidel",
+            "log_convergence": True,
+        }
+        user_settings = self._regionalisation_config.get("mda", {}) or {}
+        settings.update(user_settings)
+        return settings
 
     def _initialize_data_containers(self):
         """Initialize data containers following AeroMAPSProcess structure.
@@ -846,6 +1027,16 @@ class MultiRegionalProcess(AeroMAPSProcess):
                 # Float outputs
                 for key, value in model.float_outputs.items():
                     self.data["float_outputs"][f"{region_id}:{key}"] = value
+
+        # Global (non-namespaced) models already own fully-qualified column names
+        # ("EU:price", "world_total_demand"), so their frames are harvested as-is.
+        for model_name in self._global_model_names:
+            model = self.models[model_name]
+            if hasattr(model, "df") and model.df.columns.size:
+                for col in model.df.columns:
+                    vector_series[col] = model.df[col]
+            for key, value in model.float_outputs.items():
+                self.data["float_outputs"][key] = value
 
         # Get global (aggregated) outputs from MDA local_data
         local_data = self.mda_chain.local_data

--- a/aeromaps/models/impacts/emissions/co2_emissions.py
+++ b/aeromaps/models/impacts/emissions/co2_emissions.py
@@ -243,11 +243,13 @@ class CO2Emissions(AeroMAPSModel):
         energy_types = ["dropin_fuel", "hydrogen", "electric"]
 
         # Locally fill incomplete emission factors with zeros so that sums are not nan.
-        co2_emission_factor_by_energy_type = {}
-        for energy_type in energy_types:
-            co2_emission_factor = input_data[f"{energy_type}_mean_co2_emission_factor"]
-            co2_emission_factor.fillna(0, inplace=True)
-            co2_emission_factor_by_energy_type[energy_type] = co2_emission_factor
+        # ``fillna`` must NOT be in place: input_data holds the very Series objects the
+        # MDA snapshotted as its previous iterate, so mutating one silently rewrites
+        # that snapshot and corrupts the residual of this coupling variable.
+        co2_emission_factor_by_energy_type = {
+            energy_type: input_data[f"{energy_type}_mean_co2_emission_factor"].fillna(0)
+            for energy_type in energy_types
+        }
 
         load_factor = input_data["load_factor"]
         output_data = {}

--- a/aeromaps/models/impacts/generic_energy_model/bottom_up/production_capacity.py
+++ b/aeromaps/models/impacts/generic_energy_model/bottom_up/production_capacity.py
@@ -110,8 +110,14 @@ class BottomUpCapacity(AeroMAPSModel):
         """
         output_data = {}
 
-        # Get the energy consumption trajectory and capacity factor
+        # Get the energy consumption trajectory and capacity factor.
+        # Copied because the virtual-years block below extends and re-sorts this Series
+        # in place: input_data holds the very Series objects the MDA snapshotted as its
+        # previous iterate, and this one is a coupling variable, so mutating it would
+        # rewrite that snapshot -- here even changing its length.
         energy_required = input_data.get(f"{self.pathway_name}_energy_consumption")
+        if energy_required is not None:
+            energy_required = energy_required.copy()
 
         technology_introduction = input_data.get(
             f"{self.pathway_name}_technology_introduction_year"

--- a/aeromaps/tests/core/test_mda_input_mutation.py
+++ b/aeromaps/tests/core/test_mda_input_mutation.py
@@ -1,0 +1,123 @@
+"""Guard against disciplines mutating their MDA inputs in place.
+
+GEMSEO snapshots the previous MDA iterate with ``self.io.data.copy()``, which is a
+*shallow* copy: the pandas Series it holds are the very objects handed to each
+discipline's ``compute()`` as ``input_data``. A discipline that mutates one of them in
+place therefore rewrites the snapshot the solver is about to difference against, and
+the residual of that coupling variable becomes meaningless.
+
+The failure is silent and can go either way. Two real cases were found this way:
+
+- ``CO2Emissions`` did ``co2_emission_factor.fillna(0, inplace=True)`` on a coupling
+  input. For an all-NaN emission factor the output side of the residual converted to
+  the ``-999999`` NaN sentinel while the input side had been rewritten to ``0``, so the
+  residual held a constant ``999999`` per element and pinned the normalized residual at
+  ~1.6e-6 -- above any usable tolerance, forever.
+- ``BottomUpCapacity`` extended a coupling input with "virtual years" and re-sorted it
+  in place, changing its *length*.
+
+In the other direction, mutating an input to match the output would drive a residual
+artificially to zero and report convergence that never happened.
+
+This test asserts the invariant directly: after ``compute()``, every value a discipline
+received must be unchanged in value, dtype, length and index.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aeromaps import create_process
+from aeromaps.core.gemseo import AeroMAPSAutoModelWrapper, AeroMAPSCustomModelWrapper
+
+CONFIG_DIR = Path(__file__).parent.parent / "tested_configs"
+
+# Configs whose chains contain coupling loops, so disciplines really are re-executed
+# against a snapshotted iterate.
+COUPLED_CONFIGS = [
+    CONFIG_DIR / "config_basic.yaml",
+    CONFIG_DIR / "config_elasticity_demand.yaml",
+]
+
+
+def _snapshot(input_data):
+    """Copy every mutable value so later comparison is against a true 'before'."""
+    snapshot = {}
+    for name, value in input_data.items():
+        if isinstance(value, pd.Series):
+            snapshot[name] = (value.to_numpy(copy=True), value.index.to_numpy(copy=True))
+        elif isinstance(value, np.ndarray):
+            snapshot[name] = (value.copy(), None)
+    return snapshot
+
+
+def _find_mutations(discipline_name, snapshot, input_data):
+    """Return a list of human-readable descriptions of any in-place change."""
+    problems = []
+    for name, (before_values, before_index) in snapshot.items():
+        value = input_data[name]
+        after_values = value.to_numpy() if isinstance(value, pd.Series) else np.asarray(value)
+
+        if before_values.shape != after_values.shape:
+            problems.append(
+                f"{discipline_name}: input '{name}' changed length "
+                f"{before_values.shape} -> {after_values.shape}"
+            )
+            continue
+
+        if not np.array_equal(before_values, after_values, equal_nan=True):
+            n = int((~_equal_elementwise(before_values, after_values)).sum())
+            problems.append(
+                f"{discipline_name}: input '{name}' had {n} element(s) rewritten in place"
+            )
+
+        if before_index is not None and isinstance(value, pd.Series):
+            after_index = value.index.to_numpy()
+            if before_index.shape == after_index.shape and not np.array_equal(
+                before_index, after_index
+            ):
+                problems.append(f"{discipline_name}: index of input '{name}' was reordered")
+    return problems
+
+
+def _equal_elementwise(a, b):
+    """Element-wise equality treating NaN as equal to NaN."""
+    with np.errstate(invalid="ignore"):
+        return (a == b) | (np.isnan(a) & np.isnan(b))
+
+
+@pytest.fixture
+def mutation_recorder(monkeypatch):
+    """Patch both AeroMAPS discipline wrappers to record any input mutation."""
+    problems = []
+
+    for wrapper in (AeroMAPSCustomModelWrapper, AeroMAPSAutoModelWrapper):
+        original_run = wrapper._run
+
+        def make_run(original, wrapper_cls):
+            def _run(self, input_data):
+                snapshot = _snapshot(input_data)
+                result = original(self, input_data)
+                problems.extend(_find_mutations(self.name, snapshot, input_data))
+                return result
+
+            return _run
+
+        monkeypatch.setattr(wrapper, "_run", make_run(original_run, wrapper))
+
+    return problems
+
+
+@pytest.mark.parametrize("config_file", COUPLED_CONFIGS, ids=lambda p: p.stem)
+def test_disciplines_do_not_mutate_their_inputs(config_file, mutation_recorder):
+    """No discipline may modify a value it was handed, in any AeroMAPS chain."""
+    process = create_process(configuration_file=config_file)
+    process.compute()
+
+    assert not mutation_recorder, (
+        "Disciplines mutated their MDA inputs in place, which corrupts the solver's "
+        "previous-iterate snapshot and silently invalidates the residual:\n  "
+        + "\n  ".join(sorted(set(mutation_recorder)))
+    )


### PR DESCRIPTION
Three independent fixes to the MDA / multi-regional machinery, found while spiking a
global fuel-market discipline. The spike code itself is **not** in this PR — only the
general fixes, one per commit, each reviewable on its own.

Two of them are latent bugs that affect any AeroMAPS user today; the third is the small
capability that was missing from `unified_mda`.

---

## 1. Disciplines mutating their MDA inputs — the residual floor (`33d0f31d`)

**The bug.** GEMSEO snapshots the previous MDA iterate with `self.io.data.copy()`, which
is a **shallow** copy: the `pd.Series` it holds are the very objects handed to each
discipline's `compute()` as `input_data`. A discipline that mutates one in place
therefore rewrites the snapshot the solver is about to difference against, and the
residual of that coupling variable stops meaning anything.

`CO2Emissions` did exactly that:

```python
co2_emission_factor = input_data[f"{energy_type}_mean_co2_emission_factor"]
co2_emission_factor.fillna(0, inplace=True)   # comment said "locally fill" — inplace is not local
```

For an all-NaN emission factor (a scenario with no hydrogen and no electric aircraft, i.e.
most scenarios) the **output** side of the residual converts to the `-999999` NaN sentinel
while the **input** side has already been rewritten to `0`. The difference is a constant
`999999` per element, forever. That pins the normalized residual at ~1.6e-6 — above the
`tolerance=1e-10` that `create_process` asks for.

Confirmed by object identity: same `id()`, `nan=51` at the top of `_iterate_once`, `nan=0`
by the time the residual is computed.

`BottomUpCapacity` had the same defect in a worse form — it appended "virtual years" to
`{pathway}_energy_consumption` and re-sorted it in place, changing a coupling variable's
**length**.

**Why it matters.** With stock settings (`tolerance=1e-10`, `max_mda_iter=200`), on
`aeromaps/tests/tested_configs/config_elasticity_demand.yaml`:

| | iterations | final residual | converged? |
|---|---|---|---|
| `main` | 160 (gave up: 8 consecutive unsuccessful) | 3.34e-07 | **no** |
| this PR | 109 | 6.19e-11 | yes |

So on `main` the price-elastic demand loop silently never reaches the tolerance the code
deliberately asks for. Note the failure is silent in *both* directions — a discipline that
mutated an input toward its output would drive a residual artificially to zero and report
a convergence that never happened.

**What is *not* changed.** The `-999999` sentinel in `CustomDataConverter` was never the
problem and is untouched. Once nothing mutates the snapshot it works exactly as designed:
NaN maps to the sentinel on both sides, the difference is zero, and the variable
contributes nothing to the residual. **No NaN is turned into a fake zero** — all-NaN
columns stay all-NaN (214 of them in the two-region scenario I checked).

**The fix**: non-mutating `.fillna(0)` in one model, `.copy()` before extending in the
other. Plus `aeromaps/tests/core/test_mda_input_mutation.py`, which asserts the invariant
directly across every discipline of a chain and names the offending discipline and
variable when it fails. Verified in both directions — it does fail when either mutation
is reintroduced.

> **Reviewer note:** this is the invariant worth taking away from the PR — *never mutate a
> value you receive in `input_data`*. `.fillna(0)` not `.fillna(0, inplace=True)`,
> `.copy()` before any `.loc[...] =` or `sort_index(inplace=True)`.

---

## 2. Every output column duplicated on repeated `compute()` (`42a1af2f`)

**The bug.** `_update_data_from_unified_mda` and `_aggregate_regional_outputs` both built
`data["vector_outputs"]` / `data["climate_outputs"]` by concatenating the new series onto
the *existing* frame. A second `compute()` on the same process appended a second copy of
every column instead of refreshing it. Once a column name is duplicated, `df[col]` returns
a **DataFrame instead of a Series** and downstream code misbehaves in ways that are hard
to trace back here.

Reproducible on the stock two-region tutorial, unchanged from `main`, **both execution
modes**:

```
main      cols per compute() = [823, 1646, 2469]   duplicated = 1646
this PR   cols per compute() = [823,  823,  823]   duplicated = 0
```

**The fix.** Both call sites go through a small `_concat_series` helper that drops the
names being rewritten before concatenating — still a single `concat`, so the
anti-fragmentation intent of the original code is preserved. Values are bit-identical run
to run.

---

## 3. `unified_mda` could not host a non-namespaced discipline (`af19caf0`)

This one is a **capability addition rather than a bug fix**, so review it as such — it is
the largest diff and the only one that adds config surface. It is also independently
droppable if you would rather take 1 and 2 alone.

**The gap.** `unified_mda` had no way to host a discipline that reads one region's
variable and writes another's. The only route into the chain was `top_level_models`, which
namespaces the discipline to `{global_namespace}:` and thereby confines it to the
aggregated series. `RegionalAggregator` was the sole non-namespaced discipline and it was
hard-wired.

**The addition.** A `regionalisation.global_models` block, with the same
standards/customs structure as a regional models block. A global model is wrapped
**without** namespacing, so its grammar is written directly in namespaced terms
(`{region}:var`), exactly like the aggregator's. Unlike `_wrap_top_level_model`,
`_wrap_global_model` injects the region list and the global namespace and *then* calls
`custom_setup()`, so a model that builds its I/O dynamically from the region list gets a
real grammar instead of the placeholder from its `__init__`.

Declaring a global model under `separate_processes` now raises instead of being silently
ignored — that mode cannot solve a loop across regions.

Also in this commit:

- **Harvesting of global-model outputs** in `_update_data_from_unified_mda`. Previously
  only `{global_namespace}:`-prefixed keys were collected from `local_data`, so a global
  model's outputs never reached `data["vector_outputs"]`.
- `_register_models_into` factored out of `_register_top_level_models`.

~~A `regionalisation.mda` block to override the hard-coded MDAChain settings.~~ Removed in
`83d203eb` after review — MDA settings stay hard-coded and are tuned from the notebook on
the GEMSEO objects, as `process.py` does. The `MDAChain` construction is byte-identical to
`main` again, apart from a comment recording the tuning trap: `over_relaxation_factor` and
`acceleration_method` are not `BaseMDASettings` fields, so `MDAChain` never forwards them
to its inner MDAs — they must be set on `mda_chain.inner_mdas[i]`.

**Defaults are unchanged** — a config without a `global_models` or `mda` block behaves
exactly as before.

---

## Verification

- `pytest aeromaps/tests/core` — **28 passed** on this branch (serial run; running two
  pytest processes concurrently makes them collide over `tested_configs/tmp`).
- Two-region tutorial, both modes, on this branch: identical results
  (`co2_emissions` 2050 = 2.0801152004054027 in `unified_mda` and in
  `separate_processes`), stable column count across three consecutive `compute()` calls.
- Before/after numbers in sections 1 and 2 measured by running the same script against a
  clean `main` worktree and against this branch.

**Coverage gap worth flagging:** `aeromaps/core/multi_regional_process.py` has *no*
automated test coverage on `main` — nothing under `aeromaps/tests/` exercises
`MultiRegionalProcess` at all. Commits 2 and 3 are therefore verified by the manual runs
above, not by CI. Adding a multi-regional test is out of scope here but is the obvious
follow-up.

## Review order suggestion

`33d0f31d` first (smallest, highest impact), then `42a1af2f`, then `af19caf0`.
